### PR TITLE
DOC-27 licenses: Add SPDX license headers

### DIFF
--- a/templates/licenses/Apache-2.0.txt
+++ b/templates/licenses/Apache-2.0.txt
@@ -1,3 +1,6 @@
+Valid-License-Identifier: Apache-2.0
+License-Text:
+
 Apache License
 
 Version 2.0, January 2004

--- a/templates/licenses/CC0-1.0.txt
+++ b/templates/licenses/CC0-1.0.txt
@@ -1,3 +1,6 @@
+Valid-License-Identifier: CC0-1.0
+License-Text:
+
 Creative Commons Legal Code
 
 CC0 1.0 Universal CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES

--- a/templates/licenses/GPL-3.0-or-later.txt
+++ b/templates/licenses/GPL-3.0-or-later.txt
@@ -1,3 +1,6 @@
+Valid-License-Identifier: GPL-3.0-or-later
+License-Text:
+
 GNU GENERAL PUBLIC LICENSE
 
 Version 3, 29 June 2007

--- a/templates/licenses/MPL-2.0.txt
+++ b/templates/licenses/MPL-2.0.txt
@@ -1,3 +1,6 @@
+Valid-License-Identifier: MPL-2.0
+License-Text:
+
 Mozilla Public License Version 2.0
 
    1. Definitions


### PR DESCRIPTION
This will make sure that adding a license to a new project is as simple as copying the correct file and renaming it to `LICENSE`, without the extra step of adding the header (which is mandatory).