### PR TITLE
Update "Fixed #1" comment in PR template

### DIFF
--- a/templates/.github/pull_request_template.md
+++ b/templates/.github/pull_request_template.md
@@ -20,7 +20,7 @@ another describing your solution.
 <!--
 - Short description of how the PR relates to the issue, including an issue link.
 For example
-- Fixed #1 by adding lenses to exported items
+- Fixed #100500 by adding lenses to exported items
 
 Write 'None' if there are no related issues (which is discouraged).
 -->


### PR DESCRIPTION
Problem: some services (e. g. gitlab.com) treat "Fixed #1" comment
as a statement that this PR/MR fixes issue #1 (even though it's a
comment). Because of that each PR which uses that template may be
considered as a fix for #1.
Solution: replace it with #100500 and hope that no repo will have
so many issues.