### PR TITLE
Update the copyright format

### DIFF
--- a/templates/.github/CONTRIBUTING.md
+++ b/templates/.github/CONTRIBUTING.md
@@ -44,8 +44,7 @@ but, basically, it all boils down to the following:
     file – it is not as hard as it might sound):
 
     ```haskell
-    {-
-     - © 2019 Serokell <hi@serokell.io>
+    {- SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
      -
      - SPDX-License-Identifier: MPL-2.0
      -}
@@ -76,4 +75,4 @@ but, basically, it all boils down to the following:
 These simple rules should cover most of situation you are likely to encounter.
 In case of doubt, consult the [REUSE Practices][reuse] document.
 
-[reuse]: https://reuse.software/practices/2.0/
+[reuse]: https://reuse.software/spec/

--- a/templates/reuse/dep5
+++ b/templates/reuse/dep5
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: .gitlab/*
-Copyright: 2019 Serokell <hi@serokell.io>
+Copyright: 2019 Serokell <https://serokell.io>
 License: MPL-2.0


### PR DESCRIPTION
* REUSE 3.0 is out
* Use Serokell website instead of email, as allowed by the spec
* Make the copyright comment slightly more compact