### PR TITLE
Fix license templates for REUSE 3.0

### DIFF
--- a/templates/reuse/licenses/Apache-2.0.txt
+++ b/templates/reuse/licenses/Apache-2.0.txt
@@ -1,6 +1,3 @@
-Valid-License-Identifier: Apache-2.0
-License-Text:
-
 Apache License
 
 Version 2.0, January 2004

--- a/templates/reuse/licenses/CC0-1.0.txt
+++ b/templates/reuse/licenses/CC0-1.0.txt
@@ -1,6 +1,3 @@
-Valid-License-Identifier: CC0-1.0
-License-Text:
-
 Creative Commons Legal Code
 
 CC0 1.0 Universal CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES

--- a/templates/reuse/licenses/GPL-3.0-or-later.txt
+++ b/templates/reuse/licenses/GPL-3.0-or-later.txt
@@ -1,6 +1,3 @@
-Valid-License-Identifier: GPL-3.0-or-later
-License-Text:
-
 GNU GENERAL PUBLIC LICENSE
 
 Version 3, 29 June 2007

--- a/templates/reuse/licenses/MPL-2.0.txt
+++ b/templates/reuse/licenses/MPL-2.0.txt
@@ -1,6 +1,3 @@
-Valid-License-Identifier: MPL-2.0
-License-Text:
-
 Mozilla Public License Version 2.0
 
    1. Definitions


### PR DESCRIPTION
This is a fixup for the previous change.
`Valid-License-Identifier` is no longer supported.