### PR TITLE
Write about Resolves keyword in RP template

### DIFF
--- a/templates/.github/pull_request_template.md
+++ b/templates/.github/pull_request_template.md
@@ -15,6 +15,10 @@ another describing your solution.
 -->
 
 [//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
+[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
+[//]: # (In this case please also prefix the link with "Resolves" keyword)
+[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
+[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
 ## Related issue(s)
 
 <!--


### PR DESCRIPTION
Problem: GitHub and GitLab have special keywords to close an issue when
a PR is merged, but our PR template doesn't encourage their usage.
Most commonly a PR closes an issue, so it makes sense to use a
corresponding keyword.

Solution: add a meta-comment that asks to add "Resolves" prefix for
GitHub/GitLab issue trackers.
Also ask to use short link in this case because it's more stable.