### PR TITLE
Add issue templates

### DIFF
--- a/templates/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/templates/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: If you think our software behaves not the way it should, report a bug
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+# Description
+
+<!--
+A clear and concise description of what the bug is.
+-->
+
+# To Reproduce
+
+Steps to reproduce the behavior:
+<!--
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+# Expected behavior
+
+<!--
+A clear and concise description of what you expected to happen.
+-->
+
+# Environment
+
+- OS
+- branch/revision
+
+# Additional context
+
+<!--
+Add any other context about the problem here.
+-->

--- a/templates/.github/ISSUE_TEMPLATE/task.md
+++ b/templates/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,20 @@
+---
+name: Task
+about: Suggest a task for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Clarification and motivation
+
+<!--
+Clarify what you want to be done and why.
+-->
+
+# Acceptance criteria
+
+<!--
+Clarify how we can verify that the task is done.
+-->


### PR DESCRIPTION
Problem: if issues are enabled for a repository, usually you want
people to create good issues. Issue templates help us enforce that.

Solution: add simple issue templates for GitHub.
They are very similar to what we have in YouTrack. We distinguish
bugs and tasks.
Relevant GitHub docs:
https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository