### PR TITLE
Add package.yaml template

### DIFF
--- a/templates/haskell/package.yaml
+++ b/templates/haskell/package.yaml
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# Use this file as a reference when you create package.yaml for your new package.
+# If you have multiple packages, you may wish to extract common
+# definitions into a separate file.
+# Why we need this template:
+# • harmless default extensions
+# • a good set of warnings
+# • metadata fields that are better be set
+# • some tricks (e. g. RTS options)
+
+## Don't forget to update the name ☺
+name: myproject
+## Version is 0 by default to indicate that the package is not ready to be used
+## and has never been released/uploaded to Hackage.
+## When you think it's ready to be released, set the version to something like 0.1.0.
+version: 0
+## Adjust/add more authors if necessary.
+## If the package is developed by a small number of people, this field
+## can be set to that specific group of people.
+## More often there is a dedicated team that works on the package and changes
+## over time, so Serokell should be a good default.
+author: Serokell <hi@serokell.io>
+## For repos on github
+github: serokell/myproject
+## For git repos on a platform other than github (e. g. gitlab)
+# git: https://gitlab.com/morley-framework/morley.git
+## `homepage` and `bug-reports` are automatically set if `github` is set.
+## You can set them explicitly if the repo is not on github or you just want
+## to customize values.
+# homepage: https://gitlab.com/morley-framework/morley
+# bug-reports: https://gitlab.com/morley-framework/morley/-/issues
+
+## Description of what the package does
+synopsis: Template package.yaml file
+description:
+  Use this file as a reference when you create package.yaml for your new package.
+category: Template
+
+## Legal (be careful here)
+## We have some guidelines in Notion:
+## https://www.notion.so/serokell/How-to-94ac7fac091a4327a9a812783ce2c2cd#9203b587722e43f9bd840b32a7ba25f9
+## If the package is developed for a customer, most likely they are the copyright owners.
+## Otherwise, most likely the copyright owner is Serokell.
+copyright: 2020 Serokell <https://serokell.io>
+## Make sure the license file exists (hpack will warn you if it doesn't).
+license-file: LICENSE
+## hpack deduces the `license` field automatically based on the `license-file`.
+## So normally you don't have to set it explicitly, but you can if you want.
+## If you are curious which license to use, check out our Notion.
+# license: MPL-2.0
+
+## Additional fields:
+## Maintainer defaults to the value of `author`. Sometimes you may want to override it.
+# maintainer: Maintainers of this package <we-maintain@this.package>
+## For generally useful libraries it's a good idea to support more than 1 GHC version and
+## explicitly mention it in the package description.
+# tested-with: GHC == 8.6.5, GHC == 8.8.3, GHC = 8.10.1
+
+
+# We enable all extensions that we consider harmless by default.
+# Maybe it spoils compilation times, we should check it, see INT-162.
+# You may want to add NoImplicitPrelude here.
+default-extensions:
+  - AllowAmbiguousTypes
+  - BangPatterns
+  - BlockArguments
+  - ConstraintKinds
+  - DataKinds
+  - DefaultSignatures
+  - DeriveAnyClass
+  - DeriveDataTypeable
+  - DeriveFoldable
+  - DeriveFunctor
+  - DeriveGeneric
+  - DeriveTraversable
+  - DerivingStrategies
+  - DerivingVia
+  - EmptyCase
+  - FlexibleContexts
+  - FlexibleInstances
+  - GADTs
+  - GeneralizedNewtypeDeriving
+  - LambdaCase
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - NamedFieldPuns
+  - NegativeLiterals
+  - NumDecimals
+  - OverloadedLabels
+  - OverloadedStrings
+  - PatternSynonyms
+  - PolyKinds
+  - QuasiQuotes
+  - RankNTypes
+  - RecordWildCards
+  - RecursiveDo
+  - ScopedTypeVariables
+  - StandaloneDeriving
+  - StrictData
+  - TemplateHaskell
+  - TupleSections
+  - TypeApplications
+  - TypeFamilies
+  - TypeOperators
+  - UndecidableInstances
+  - UndecidableSuperClasses
+  - ViewPatterns
+
+ghc-options:
+  -Weverything
+  -Wno-missing-exported-signatures
+  -Wno-missing-import-lists
+  -Wno-missed-specialisations
+  -Wno-all-missed-specialisations
+  -Wno-unsafe
+  -Wno-safe
+  -Wno-missing-local-signatures
+  -Wno-monomorphism-restriction
+  -Wno-implicit-prelude
+
+when:
+  - condition: impl(ghc >= 8.10.0)
+    ghc-options:
+      - -Wno-prepositive-qualified-module
+      - -Wno-inferred-safe-imports
+      - -Wno-missing-safe-haskell-mode
+
+# Note that `hpack` (apparently) concatenates lists automatically.
+# So if you define `dependencies` for a component, they will be concatenated
+# with this list.
+dependencies:
+  # Usually base is used by all components.
+  # However, you may want to use `base-noprelude` to be able to replace
+  # the standard `Prelude` with a custom one.
+  # Note that you can use cabal's mixins feature for that,
+  # but it breaks `stack repl` (`cabal repl` works fine).
+  # https://github.com/commercialhaskell/stack/issues/5077
+  # Also it's recommended to setup bounds on the version here.
+  - base
+
+library:
+  source-dirs: src
+
+executables:
+  myproject:
+    main:                Main.hs
+    source-dirs:         app
+
+tests:
+  myproject-test:
+    main:        Main.hs
+    source-dirs: test
+    # We often use tasty-discover.
+    build-tools: tasty-discover:tasty-discover
+
+    ghc-options:
+    # tasty runs tests in parallel, so using multiple threads should be useful.
+    - -threaded
+    # should be harmless, but helps some people analyse something :shrug:
+    - -eventlog
+
+    # Enable -N to use multiple threads.
+    # Increase allocation area by using the recommended -A64m option.
+    # Also increase the allocation area for large objects with -AL256m,
+    # since this area is shared between all threads and thus with high -N
+    # values get used up too soon.
+    #
+    # With these options tests usually run faster.
+    #
+    # Weird quoting is required for cabal to correctly pass this as _one_ option,
+    # otherwise it splits by spaces.
+    - '"-with-rtsopts=-N -A64m -AL256m"'
+
+    dependencies:
+    - tasty


### PR DESCRIPTION
Problem: in Haskell packages we often use `package.yaml` file.
Some parts of it are often shared by our repos.
Hence we want to extract them into a template, so that when we create
a new package we can use all our standard things.

Solution: add a template package.yaml. See comments for details.