### PR TITLE
haskell: Enable NoStarIsType

### DIFF
--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -88,6 +88,7 @@ default-extensions:
   - MultiWayIf
   - NamedFieldPuns
   - NegativeLiterals
+  - NoStarIsType
   - NumDecimals
   - OverloadedLabels
   - OverloadedStrings


### PR DESCRIPTION
`StarIsType` is a legacy extensions that makes `*` desugar into `Type`.
This is legacy and conflicts with `TypeOperators`.

Use `NoStarIsType` by default.

(Since GHC 8.6.1.)
